### PR TITLE
docs: add example for query parameter-based rewrites with intercepting routes

### DIFF
--- a/docs/advanced-features/middleware.md
+++ b/docs/advanced-features/middleware.md
@@ -135,6 +135,38 @@ export function middleware(request: NextRequest) {
 }
 ```
 
+### Rewriting Based on Query Parameters
+
+You can use query parameters to conditionally rewrite to different routes. This is useful when you want to trigger [Intercepting Routes](/docs/app/building-your-application/routing/intercepting-routes) only for specific links, such as a "Quick View" modal.
+
+For example, to show an intercepted product modal only when `?quick=1` is present:
+
+```typescript
+// middleware.ts
+
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  const { pathname, searchParams } = request.nextUrl
+
+  // Rewrite /products/[slug]?quick=1 to /products/[slug]/quick
+  // This allows the /products/[slug]/quick route to be intercepted
+  if (pathname.startsWith('/products/') && searchParams.get('quick') === '1') {
+    const newUrl = new URL(`${pathname}/quick`, request.url)
+    // Remove the query parameter from the rewritten URL
+    newUrl.searchParams.delete('quick')
+    return NextResponse.rewrite(newUrl)
+  }
+}
+
+export const config = {
+  matcher: '/products/:path*',
+}
+```
+
+With this middleware, linking to `/products/foo?quick=1` will render the intercepted route at `(.)/products/[slug]/quick`, while linking to `/products/foo` will render the full product page normally.
+
 ## NextResponse
 
 The [`NextResponse`](#nextresponse) API allows you to:


### PR DESCRIPTION
## Summary

- Adds a new section to the middleware documentation showing how to use query parameters to conditionally trigger rewrites
- This pattern enables "Quick View" modals that only intercept routes when a specific query parameter is present (e.g., `?quick=1` → rewrite to `/products/[slug]/quick`)
- Useful for e-commerce sites that want intercepted product modals without intercepting every product page link

## Example Use Case

Instead of intercepting all product page navigations, you can selectively trigger interception:
- `/products/foo` → renders the full product page
- `/products/foo?quick=1` → middleware rewrites to `/products/foo/quick`, which gets intercepted as a modal

## Slack Thread

https://vercel.slack.com/archives/C03S8ED1DKM/p1778613054234459?thread_ts=1778612529.170869&cid=C03S8ED1DKM

https://claude.ai/code/session_01W9JcpfU3Pp8gCMXjf8JCLV

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9JcpfU3Pp8gCMXjf8JCLV)_